### PR TITLE
fix: Apply light theme corrections to Celebration page

### DIFF
--- a/src/app/celebrate/page.tsx
+++ b/src/app/celebrate/page.tsx
@@ -3,18 +3,18 @@
 
 import React from 'react';
 import AppHeader from '@/components/layout/AppHeader';
-import ConfettiBar from '@/components/ui/ConfettiBar';
-import { Check, Share2 } from 'lucide-react';
+// ConfettiBar import removed
+import { Check, Share2 } from 'lucide-react'; // Keep other necessary icons
 
 export default function CelebrationPage() {
   const userName = "Sarah";
 
   return (
-    // Root container for the page
-    <div className="min-h-screen bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-blue-50 via-white to-slate-100 text-gray-800 font-sans flex flex-col relative"> {/* Removed items-center justify-center to allow natural flow and scrolling if card is tall */}
-      <ConfettiBar />
+    // Updated root div classes for background
+    <div className="min-h-screen bg-[radial-gradient(ellipse_at_center,_var(--tw-gradient-stops))] from-blue-50 to-slate-50 text-gray-800 font-sans flex flex-col relative">
+      {/* ConfettiBar element removed */}
 
-      <div className="absolute top-0 left-0 right-0 z-10"> {/* Or simply ensure AppHeader is first in flow if not fixed */}
+      <div className="absolute top-0 left-0 right-0 z-10">
         <AppHeader showSettingsIcon={false} isTransparent={true} />
       </div>
 


### PR DESCRIPTION
This commit addresses feedback to ensure the Celebration page (`app/celebrate/page.tsx`) aligns with the intended light-mode design.

Key corrections include:

1.  **Confetti Removal**: The `ConfettiBar` component and its associated elements have been removed from the page.
2.  **Page Background**: The page background is set to a light radial gradient (`bg-gradient-radial from-blue-50 to-slate-50`). Any previous dark background styles have been removed.
3.  **Application Header**: Verified that the standard `AppHeader` is used and correctly configured with `isTransparent={true}` to show the gradient background through it.
4.  **Text & Icon Colors**:
    *   The main heading ("Congratulations, Sarah!") text color is set to dark gray (`text-gray-800`).
    *   The sub-text ("You've smashed your goal...") text color is set to medium gray (`text-gray-600`).
    *   The success icon (checkmark in a circle) colors are corrected for a light theme (outer circle `bg-green-100`, inner icon `text-green-600`).
5.  **Graphic Placeholder**: The "Shareable Graphic" placeholder styling is confirmed to use a light background (`bg-slate-100`) and a border.

These changes ensure the Celebration page has the correct visual appearance as per the latest design requirements.